### PR TITLE
メモリ不足になるとMySelfが解放されてアクセストークンが取得できなくなるバグの修正

### DIFF
--- a/app/src/main/java/com/cyder/atsushi/youtubesync/MainActivity.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/MainActivity.java
@@ -6,6 +6,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.content.Intent;
 import android.os.Bundle;
 
+import com.cyder.atsushi.youtubesync.app_data.MySelf;
+
 
 public class MainActivity extends AppCompatActivity {
     @NonNull

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/RoomActivity.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/RoomActivity.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
+import com.cyder.atsushi.youtubesync.app_data.MySelf;
 import com.cyder.atsushi.youtubesync.app_data.RoomData;
 import com.cyder.atsushi.youtubesync.channels.RoomChannel;
 import com.cyder.atsushi.youtubesync.channels.RoomChannelInterface;
@@ -44,6 +45,10 @@ public class RoomActivity extends AppCompatActivity
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_video);
+
+        if (savedInstanceState != null) {
+            MySelf.restoreInstanceState(savedInstanceState);
+        }
 
         YouTubePlayerFragment frag =
                 (YouTubePlayerFragment) getFragmentManager().findFragmentById(R.id.youtube_fragment);
@@ -207,6 +212,13 @@ public class RoomActivity extends AppCompatActivity
 
     @Override
     public void onVideoStarted() {
+    }
+
+
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+        MySelf.saveInstanceState(savedInstanceState);
     }
 
     public void startSearchVideoActivity() {

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/Token.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/Token.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 
+import com.cyder.atsushi.youtubesync.app_data.MySelf;
+
 import static android.content.Context.MODE_PRIVATE;
 
 /**

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/TopActivity.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/TopActivity.java
@@ -12,6 +12,8 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
+import com.cyder.atsushi.youtubesync.app_data.MySelf;
+
 /**
  * Created by atsushi on 2017/11/03.
  */
@@ -23,6 +25,10 @@ public class TopActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_top);
+
+        if (savedInstanceState != null) {
+            MySelf.restoreInstanceState(savedInstanceState);
+        }
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.top_tool_bar);
         toolbar.setLogo(R.drawable.toolbar_logo);
@@ -70,6 +76,12 @@ public class TopActivity extends AppCompatActivity {
                 joinRoom(res);
             }
         }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+        MySelf.saveInstanceState(savedInstanceState);
     }
 
     private void joinRoom(String roomKey) {

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/app_data/MySelf.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/app_data/MySelf.java
@@ -1,4 +1,4 @@
-package com.cyder.atsushi.youtubesync;
+package com.cyder.atsushi.youtubesync.app_data;
 
 import com.cyder.atsushi.youtubesync.json_data.User;
 

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/app_data/MySelf.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/app_data/MySelf.java
@@ -1,5 +1,7 @@
 package com.cyder.atsushi.youtubesync.app_data;
 
+import android.os.Bundle;
+
 import com.cyder.atsushi.youtubesync.json_data.User;
 
 /**
@@ -9,6 +11,7 @@ import com.cyder.atsushi.youtubesync.json_data.User;
 public final class MySelf {
 
     private static User myself;
+    private static final String STATE_USER_TOKEN = "userToken";
 
     public static Boolean exists() {
         return (myself != null);
@@ -21,5 +24,13 @@ public final class MySelf {
     public static void singIn(String token) {
         myself = new User();
         myself.access_token = token;
+    }
+
+    public static void saveInstanceState(Bundle savedInstanceState) {
+        savedInstanceState.putString(STATE_USER_TOKEN, myself.access_token);
+    }
+
+    public static void restoreInstanceState(Bundle savedInstanceState) {
+        singIn(savedInstanceState.getString(STATE_USER_TOKEN));
     }
 }

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/channels/Cable.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/channels/Cable.java
@@ -2,7 +2,7 @@ package com.cyder.atsushi.youtubesync.channels;
 
 import android.util.Log;
 
-import com.cyder.atsushi.youtubesync.MySelf;
+import com.cyder.atsushi.youtubesync.app_data.MySelf;
 import com.hosopy.actioncable.ActionCable;
 import com.hosopy.actioncable.Consumer;
 

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/server/HttpRequestsHelper.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/server/HttpRequestsHelper.java
@@ -3,7 +3,7 @@ package com.cyder.atsushi.youtubesync.server;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-import com.cyder.atsushi.youtubesync.MySelf;
+import com.cyder.atsushi.youtubesync.app_data.MySelf;
 import com.cyder.atsushi.youtubesync.json_data.JsonParameter;
 import com.cyder.atsushi.youtubesync.json_data.Response;
 import com.google.gson.Gson;


### PR DESCRIPTION
close #43 
onSaveInstanceStateで保存し、onCreateで再開するようにしました。
onRestoreInstanceStateにしなかったのは、onCreate内でMySelfが呼ばれ、またonRestoreInstanceStateがonCreateより後に呼ばれるからです。

ちょっと呼ぶ場所怪しいのと、デバッグのやり方がわかりませんでした。