### PR TITLE
再生中の曲がない場合に諸々非表示にする。

### DIFF
--- a/app/src/main/java/com/cyder/atsushi/youtubesync/RoomActivity.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/RoomActivity.java
@@ -7,6 +7,7 @@ import android.support.design.widget.TabLayout;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+
 import com.cyder.atsushi.youtubesync.app_data.MySelf;
 import com.cyder.atsushi.youtubesync.app_data.RoomData;
 import com.cyder.atsushi.youtubesync.channels.RoomChannel;
@@ -21,7 +22,7 @@ import com.google.gson.JsonElement;
 
 import java.util.ArrayList;
 
-public class RoomActivity extends AppCompatActivity implements RoomChannelInterface, VideoFragment.VideoFragmentListener{
+public class RoomActivity extends AppCompatActivity implements RoomChannelInterface, VideoFragment.VideoFragmentListener {
 
     private final String TAG = this.getClass().getSimpleName();
 
@@ -132,9 +133,11 @@ public class RoomActivity extends AppCompatActivity implements RoomChannelInterf
 
         switch (jsonData.data_type) {
             case "now_playing_video":
-                if (jsonData.data != null) {
-                    if (videoFragment != null) {
+                if (videoFragment != null) {
+                    if (jsonData.data != null) {
                         videoFragment.startVideo(jsonData.data.video);
+                    } else {
+                        videoFragment.clearNowPlayingVideo();
                     }
                 }
                 break;

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/VideoFragment.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/VideoFragment.java
@@ -126,8 +126,7 @@ public class VideoFragment extends Fragment implements YouTubePlayer.OnInitializ
         if (nextVideo != null) {
             prepareVideo(nextVideo);
         } else {
-            roomData.clearNowPlayingVideo();
-            getActivity().findViewById(R.id.video_player).setVisibility(View.GONE);
+            clearNowPlayingVideo();
         }
     }
 
@@ -153,6 +152,15 @@ public class VideoFragment extends Fragment implements YouTubePlayer.OnInitializ
         });
     }
 
+    public void clearNowPlayingVideo() {
+        roomData.clearNowPlayingVideo();
+        getActivity().runOnUiThread(new Runnable() {
+            public void run() {
+                getActivity().findViewById(R.id.video_player).setVisibility(View.GONE);
+            }
+        });
+    }
+
     public void prepareVideo(final Video video) {
         if (player != null) {
             player.cueVideo(video.youtube_video_id);
@@ -166,7 +174,7 @@ public class VideoFragment extends Fragment implements YouTubePlayer.OnInitializ
             @Override
             public void run() {
                 if (player != null) {
-                    double duration = (double)player.getDurationMillis();
+                    double duration = (double) player.getDurationMillis();
                     if (duration > 0.0) {
                         int progress = (int) (((double) bar.getMax() * (double) player.getCurrentTimeMillis()) / duration);
                         bar.setProgress(progress);


### PR DESCRIPTION
close #101
APIの仕様が悪い気がしますが、再生中の曲がない場合、jsonData.data_typeが"now_playing_video"でjsonData.dataが空になります。
それに合わせて修正しました。