### PR TITLE
検索結果がおかしいバグの修正

### DIFF
--- a/app/src/main/java/com/cyder/atsushi/youtubesync/server/HttpRequestsHelper.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/server/HttpRequestsHelper.java
@@ -17,6 +17,8 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import static android.net.Uri.encode;
+
 /**
  * Created by chigichan24 on 2017/10/29.
  */
@@ -55,7 +57,7 @@ public class HttpRequestsHelper<T> {
                 } else {
                     params += "&";
                 }
-                params += key + "=" + hashParameter.get(key);
+                params += key + "=" + encode(hashParameter.get(key));
             }
         }
         communicate("GET", null, endPoint + params, callback);

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/server/HttpRequestsHelper.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/server/HttpRequestsHelper.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
  * Created by chigichan24 on 2017/10/29.
  */
 
-public class HttpRequestsHelper<T>{
+public class HttpRequestsHelper<T> {
 
     @NonNull
     private final static String TAG = HttpRequestsHelper.class.getSimpleName();

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/youtube/SearchingVideoHelper.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/youtube/SearchingVideoHelper.java
@@ -10,8 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static android.net.Uri.encode;
-
 /**
  * Created by atsushi on 2017/10/11.
  */
@@ -62,7 +60,7 @@ public class SearchingVideoHelper extends HttpRequestsHelper {
 
     private void search(final String keyword, final String pageToken) {
         HashMap<String, String> params = new HashMap<>();
-        params.put("keyword", encode(keyword));
+        params.put("keyword", keyword);
         if (pageToken != null) {
             params.put("page_token", pageToken);
         }

--- a/app/src/main/java/com/cyder/atsushi/youtubesync/youtube/SearchingVideoHelper.java
+++ b/app/src/main/java/com/cyder/atsushi/youtubesync/youtube/SearchingVideoHelper.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import static android.net.Uri.encode;
+
 /**
  * Created by atsushi on 2017/10/11.
  */
@@ -60,7 +62,7 @@ public class SearchingVideoHelper extends HttpRequestsHelper {
 
     private void search(final String keyword, final String pageToken) {
         HashMap<String, String> params = new HashMap<>();
-        params.put("keyword", keyword);
+        params.put("keyword", encode(keyword));
         if (pageToken != null) {
             params.put("page_token", pageToken);
         }


### PR DESCRIPTION
APILevel19以下の場合，HttpConnectionでどうやらUTF-8が標準で表現できない?らしく，keywordに日本語を入力しても?に化けていたので明示的にencodeを咬ますことで解決しました．