### PR TITLE
tokenを保持する．

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,11 +11,13 @@ def appVersionCode = versionMajor * 100 + versionMinor * 10 + versionPatch
 def appVersionName = "${versionMajor}.${versionMinor}.${versionPatch}"
 
 def appCompileSdkVersion = 26
+def appBuildToolsVersion = "27.0.2"
 def appPackageName = "com.cyder.atsushi.youtubesync"
 def appMinSdkVersion = 19
 def appTargetSdkVersion = 26
 
 android {
+    buildToolsVersion appBuildToolsVersion
     compileSdkVersion appCompileSdkVersion
     flavorDimensions "default"
     defaultConfig {
@@ -66,9 +68,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:26.+'
-    implementation 'com.android.support:support-v4:26.+'
-    implementation 'com.android.support:design:26.+'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:support-v4:27.0.2'
+    implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation 'junit:junit:4.12'
@@ -93,4 +95,5 @@ dependencies {
     kapt 'com.android.databinding:compiler:3.0.1'
 
     compileOnly 'javax.annotation:jsr250-api:1.0'
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
     implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'androidx.core:core-ktx:0.1'
 
     kapt 'com.google.dagger:dagger-compiler:2.14.1'
     kapt 'com.github.gfx.android.orma:orma-processor:4.2.5'

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/BaseApplication.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/BaseApplication.kt
@@ -15,7 +15,6 @@ class BaseApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        @Suppress("DEPRECATION")
         component = DaggerAppComponent.builder()
                 .appModule(AppModule(this))
                 .networkModule(NetworkModule.instance)

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/SyncPodApi.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/SyncPodApi.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
  */
 
 @Singleton
-interface SignInApi {
+interface SyncPodApi {
     @POST("login")
-    fun getSession(@Query("email") email: String, @Query("password") password: String): Single<Response>
+    fun signIn(@Query("email") email: String, @Query("password") password: String): Single<Response>
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/response/Response.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/response/Response.kt
@@ -1,5 +1,7 @@
 package com.cyder.atsushi.youtubesync.api.response
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Created by chigichan24 on 2018/01/18.
  */
@@ -8,5 +10,5 @@ data class Response(
         val result: String,
         val user: User?,
         val room: Room?,
-        val joinedRooms: List<Room>?
+        @SerializedName("joined_rooms") val joinedRooms: List<Room>?
 )

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/response/Room.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/response/Room.kt
@@ -1,5 +1,7 @@
 package com.cyder.atsushi.youtubesync.api.response
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Created by chigichan24 on 2018/01/18.
  */
@@ -9,7 +11,7 @@ data class Room(
         val name: String,
         val description: String,
         val key: String,
-        val nowPlayingVideo: Video?,
-        val lastPlatedVideo: Video?,
-        val onlineUsers: List<User>?
+        @SerializedName("now_playing_video") val nowPlayingVideo: Video?,
+        @SerializedName("last_played_video") val lastPlayedVideo: Video?,
+        @SerializedName("online_users") val onlineUsers: List<User>?
 )

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/response/User.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/api/response/User.kt
@@ -1,5 +1,7 @@
 package com.cyder.atsushi.youtubesync.api.response
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Created by chigichan24 on 2018/01/18.
  */
@@ -8,5 +10,5 @@ data class User(
         val id: Int,
         val email: String?,
         val name: String,
-        val accessToken: String?
+        @SerializedName("access_token") val accessToken: String?
 )

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/AppModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/AppModule.kt
@@ -1,6 +1,7 @@
 package com.cyder.atsushi.youtubesync.di
 
 import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import com.cyder.atsushi.youtubesync.api.SyncPodApi
 import com.cyder.atsushi.youtubesync.repository.UserDataRepository
 import com.cyder.atsushi.youtubesync.repository.UserRepository
@@ -12,14 +13,23 @@ import javax.inject.Singleton
  * Created by chigichan24 on 2018/01/12.
  */
 @Module
-class AppModule(val context: Context) {
-    @Singleton @Provides
+class AppModule(private val context: Context) {
+    @Singleton
+    @Provides
     fun provideContext(): Context = context
 
     // TODO create singleton ormadatabase
 
-    @Singleton @Provides
+    @Singleton
+    @Provides
     fun provideUserRepository(
             api: SyncPodApi
-    ): UserRepository = UserDataRepository(api)
+    ): UserRepository {
+        val pref = context.getSharedPreferences(APP_NAME, MODE_PRIVATE)
+        return UserDataRepository(api, pref)
+    }
+
+    companion object {
+        const val APP_NAME = "youtube-sync"
+    }
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/AppModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/AppModule.kt
@@ -1,7 +1,7 @@
 package com.cyder.atsushi.youtubesync.di
 
 import android.content.Context
-import com.cyder.atsushi.youtubesync.api.SignInApi
+import com.cyder.atsushi.youtubesync.api.SyncPodApi
 import com.cyder.atsushi.youtubesync.repository.UserDataRepository
 import com.cyder.atsushi.youtubesync.repository.UserRepository
 import dagger.Module
@@ -20,6 +20,6 @@ class AppModule(val context: Context) {
 
     @Singleton @Provides
     fun provideUserRepository(
-            api: SignInApi
+            api: SyncPodApi
     ): UserRepository = UserDataRepository(api)
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/FragmentModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/FragmentModule.kt
@@ -11,5 +11,5 @@ import dagger.Provides
 @Module
 class FragmentModule(val fragment: Fragment) {
     @Provides
-    fun provideFragmentManager(): FragmentManager = fragment.fragmentManager
+    fun provideFragmentManager(): FragmentManager? = fragment.fragmentManager
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.cyder.atsushi.youtubesync.di
 
+import android.content.Context
 import com.cyder.atsushi.youtubesync.api.SyncPodApi
 import dagger.Module
 import dagger.Provides
@@ -18,14 +19,15 @@ class NetworkModule {
 
     @Singleton
     @Provides
-    fun provideOkHttpClient(): OkHttpClient {
+    fun provideOkHttpClient(context: Context): OkHttpClient {
+        val data = context.getSharedPreferences("youtube-sync", Context.MODE_PRIVATE)
         return OkHttpClient.Builder()
                 .addInterceptor {
                     it.proceed(
                             it.request()
                                     .newBuilder()
                                     .addHeader("Content-Type", "application/json; charset=utf-8")
-                                    .addHeader("Authorization", "hoge")
+                                    .addHeader("Authorization", data.getString("userToken", ""))
                                     .build()
                     )
                 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
@@ -1,6 +1,5 @@
 package com.cyder.atsushi.youtubesync.di
 
-import android.content.Context
 import com.cyder.atsushi.youtubesync.api.SyncPodApi
 import dagger.Module
 import dagger.Provides
@@ -19,15 +18,13 @@ class NetworkModule {
 
     @Singleton
     @Provides
-    fun provideOkHttpClient(context: Context): OkHttpClient {
-        val data = context.getSharedPreferences("youtube-sync", Context.MODE_PRIVATE)
+    fun provideOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
                 .addInterceptor {
                     it.proceed(
                             it.request()
                                     .newBuilder()
                                     .addHeader("Content-Type", "application/json; charset=utf-8")
-                                    .addHeader("Authorization", data.getString("userToken", ""))
                                     .build()
                     )
                 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
@@ -1,6 +1,6 @@
 package com.cyder.atsushi.youtubesync.di
 
-import com.cyder.atsushi.youtubesync.api.SignInApi
+import com.cyder.atsushi.youtubesync.api.SyncPodApi
 import dagger.Module
 import dagger.Provides
 import okhttp3.OkHttpClient
@@ -34,8 +34,8 @@ class NetworkModule {
 
     @Singleton
     @Provides
-    fun provideSignInApi(@RetrofitApi retrofit: Retrofit): SignInApi {
-        return retrofit.create(SignInApi::class.java)
+    fun provideSignInApi(@RetrofitApi retrofit: Retrofit): SyncPodApi {
+        return retrofit.create(SyncPodApi::class.java)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
@@ -18,7 +18,19 @@ class NetworkModule {
 
     @Singleton
     @Provides
-    fun provideOkHttpClient():OkHttpClient = OkHttpClient.Builder().build()
+    fun provideOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+                .addInterceptor {
+                    it.proceed(
+                            it.request()
+                                    .newBuilder()
+                                    .addHeader("Content-Type", "application/json; charset=utf-8")
+                                    .addHeader("Authorization", "hoge")
+                                    .build()
+                    )
+                }
+                .build()
+    }
 
     @RetrofitApi
     @Singleton
@@ -34,7 +46,7 @@ class NetworkModule {
 
     @Singleton
     @Provides
-    fun provideSignInApi(@RetrofitApi retrofit: Retrofit): SyncPodApi {
+    fun provideSyncPodApi(@RetrofitApi retrofit: Retrofit): SyncPodApi {
         return retrofit.create(SyncPodApi::class.java)
     }
 

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/NetworkModule.kt
@@ -20,14 +20,6 @@ class NetworkModule {
     @Provides
     fun provideOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
-                .addInterceptor {
-                    it.proceed(
-                            it.request()
-                                    .newBuilder()
-                                    .addHeader("Content-Type", "application/json; charset=utf-8")
-                                    .build()
-                    )
-                }
                 .build()
     }
 

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
@@ -27,12 +27,18 @@ class UserDataRepository @Inject constructor(
                 .toCompletable()
     }
 
-    override fun getAccessToken(): Single<String>? {
-        val token = sharedPreferences.getString(STATE_USER_TOKEN, "fail")
-        if (token == "fail") {
-            return null
+    override fun getAccessToken(): Single<String> {
+        val token = sharedPreferences.getString(STATE_USER_TOKEN, null)
+
+        return Single.create { emitter ->
+            try {
+                token?.run {
+                    emitter.onSuccess(token)
+                }
+            } catch (exception: Exception) {
+                emitter.onError(exception)
+            }
         }
-        return Single.just(token)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
@@ -18,7 +18,7 @@ class UserDataRepository @Inject constructor(
 
     override fun signIn(email: String, password: String): Completable {
         val result = syncPodApi.signIn(email, password)
-        result.subscribe{ _ ->
+        result.subscribe { _ ->
             sharedPreferences.edit {
                 putString(STATE_USER_TOKEN, result.blockingGet().user?.accessToken)
             }
@@ -28,10 +28,11 @@ class UserDataRepository @Inject constructor(
     }
 
     override fun getAccessToken(): Single<String>? {
-        return Single
-                .just(sharedPreferences.getString(STATE_USER_TOKEN, "fail"))
-                .filter { it != "fail" }
-                .toSingle()
+        val token = sharedPreferences.getString(STATE_USER_TOKEN, "fail")
+        if (token == "fail") {
+            return null
+        }
+        return Single.just(token)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
@@ -1,6 +1,6 @@
 package com.cyder.atsushi.youtubesync.repository
 
-import com.cyder.atsushi.youtubesync.api.SignInApi
+import com.cyder.atsushi.youtubesync.api.SyncPodApi
 import com.cyder.atsushi.youtubesync.api.response.User
 import io.reactivex.Completable
 import io.reactivex.Flowable
@@ -11,16 +11,16 @@ import javax.inject.Inject
  * Created by chigichan24 on 2018/01/17.
  */
 class UserDataRepository @Inject constructor(
-        private val signInApi: SignInApi
+        private val syncPodApi: SyncPodApi
 ) : UserRepository {
     override val user: Flowable<User?> =
-            signInApi.getSession("debug", "debug")
+            syncPodApi.signIn("debug", "debug")
                     .map { it.user }
                     .toFlowable()
                     .subscribeOn(Schedulers.computation())
 
     override fun signIn(email: String, password: String): Completable {
-        return signInApi.getSession(email, password)
+        return syncPodApi.signIn(email, password)
                 .subscribeOn(Schedulers.computation())
                 .toCompletable()
     }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
@@ -1,5 +1,7 @@
 package com.cyder.atsushi.youtubesync.repository
 
+import android.content.SharedPreferences
+import androidx.content.edit
 import com.cyder.atsushi.youtubesync.api.SyncPodApi
 import com.cyder.atsushi.youtubesync.api.response.User
 import io.reactivex.Completable
@@ -11,7 +13,8 @@ import javax.inject.Inject
  * Created by chigichan24 on 2018/01/17.
  */
 class UserDataRepository @Inject constructor(
-        private val syncPodApi: SyncPodApi
+        private val syncPodApi: SyncPodApi,
+        private val sharedPreferences: SharedPreferences
 ) : UserRepository {
     override val user: Flowable<User?> =
             syncPodApi.signIn("debug", "debug")
@@ -20,8 +23,15 @@ class UserDataRepository @Inject constructor(
                     .subscribeOn(Schedulers.computation())
 
     override fun signIn(email: String, password: String): Completable {
-        return syncPodApi.signIn(email, password)
-                .subscribeOn(Schedulers.computation())
+        val result = syncPodApi.signIn(email, password)
+        sharedPreferences.edit {
+            putString(STATE_USER_TOKEN, result.blockingGet().user?.accessToken)
+        }
+        return result.subscribeOn(Schedulers.computation())
                 .toCompletable()
+    }
+
+    companion object {
+        const val STATE_USER_TOKEN = "userToken"
     }
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
@@ -3,9 +3,8 @@ package com.cyder.atsushi.youtubesync.repository
 import android.content.SharedPreferences
 import androidx.content.edit
 import com.cyder.atsushi.youtubesync.api.SyncPodApi
-import com.cyder.atsushi.youtubesync.api.response.User
 import io.reactivex.Completable
-import io.reactivex.Flowable
+import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
@@ -16,22 +15,27 @@ class UserDataRepository @Inject constructor(
         private val syncPodApi: SyncPodApi,
         private val sharedPreferences: SharedPreferences
 ) : UserRepository {
-    override val user: Flowable<User?> =
-            syncPodApi.signIn("debug", "debug")
-                    .map { it.user }
-                    .toFlowable()
-                    .subscribeOn(Schedulers.computation())
 
     override fun signIn(email: String, password: String): Completable {
         val result = syncPodApi.signIn(email, password)
-        sharedPreferences.edit {
-            putString(STATE_USER_TOKEN, result.blockingGet().user?.accessToken)
-        }
+        result.subscribe( {
+            sharedPreferences.edit {
+                putString(STATE_USER_TOKEN, result.blockingGet().user?.accessToken)
+            }
+        },{})
         return result.subscribeOn(Schedulers.computation())
                 .toCompletable()
+    }
+
+    override fun getAccessToken(): Single<String>? {
+        return Single
+                .just(sharedPreferences.getString(STATE_USER_TOKEN, "fail"))
+                .filter { it != "fail" }
+                .toSingle()
     }
 
     companion object {
         const val STATE_USER_TOKEN = "userToken"
     }
 }
+

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
@@ -17,13 +17,12 @@ class UserDataRepository @Inject constructor(
 ) : UserRepository {
 
     override fun signIn(email: String, password: String): Completable {
-        val result = syncPodApi.signIn(email, password)
-        result.subscribe { _ ->
-            sharedPreferences.edit {
-                putString(STATE_USER_TOKEN, result.blockingGet().user?.accessToken)
-            }
-        }
-        return result.subscribeOn(Schedulers.computation())
+        return syncPodApi.signIn(email, password)
+                .doOnSuccess { response ->
+                    sharedPreferences.edit {
+                        putString(STATE_USER_TOKEN, response.user?.accessToken)
+                    }
+                }.subscribeOn(Schedulers.computation())
                 .toCompletable()
     }
 

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserDataRepository.kt
@@ -18,11 +18,11 @@ class UserDataRepository @Inject constructor(
 
     override fun signIn(email: String, password: String): Completable {
         val result = syncPodApi.signIn(email, password)
-        result.subscribe( {
+        result.subscribe{ _ ->
             sharedPreferences.edit {
                 putString(STATE_USER_TOKEN, result.blockingGet().user?.accessToken)
             }
-        },{})
+        }
         return result.subscribeOn(Schedulers.computation())
                 .toCompletable()
     }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserRepository.kt
@@ -11,5 +11,5 @@ interface UserRepository {
     //TODO implement val user
     @CheckResult
     fun signIn(email: String, password:String): Completable
-    fun getAccessToken(): Single<String>?
+    fun getAccessToken(): Single<String>
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/UserRepository.kt
@@ -1,15 +1,15 @@
 package com.cyder.atsushi.youtubesync.repository
 
 import android.support.annotation.CheckResult
-import com.cyder.atsushi.youtubesync.api.response.User
 import io.reactivex.Completable
-import io.reactivex.Flowable
+import io.reactivex.Single
 
 /**
  * Created by chigichan24 on 2018/01/18.
  */
 interface UserRepository {
-    val user: Flowable<User?>
+    //TODO implement val user
     @CheckResult
     fun signIn(email: String, password:String): Completable
+    fun getAccessToken(): Single<String>?
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/BaseActivity.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/BaseActivity.kt
@@ -29,7 +29,7 @@ abstract class BaseActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
-        viewModel?.onResume()
+        viewModel?.onStart()
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
@@ -15,7 +15,6 @@ class MainActivityViewModel @Inject constructor(
         private val repository: UserRepository
 ) : ActivityViewModel() {
     override fun onStart() {
-        decideLaunchActivity()
     }
 
     override fun onResume() {
@@ -36,9 +35,9 @@ class MainActivityViewModel @Inject constructor(
 
     private fun decideLaunchActivity() {
         repository.getAccessToken()
-                ?.subscribe { _ ->
+                .subscribe({
                     navigator.closeActivity()
                     navigator.navigateToTopActivity()
-                }
+                }, {})
     }
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
@@ -36,11 +36,9 @@ class MainActivityViewModel @Inject constructor(
 
     private fun decideLaunchActivity() {
         repository.getAccessToken()
-                ?.subscribe({
+                ?.subscribe { _ ->
                     navigator.closeActivity()
                     navigator.navigateToTopActivity()
-                }, {
-
-                })
+                }
     }
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
@@ -1,6 +1,7 @@
 package com.cyder.atsushi.youtubesync.viewmodel
 
 import android.view.View
+import com.cyder.atsushi.youtubesync.repository.UserRepository
 import com.cyder.atsushi.youtubesync.view.helper.Navigator
 import com.cyder.atsushi.youtubesync.viewmodel.base.ActivityViewModel
 import javax.inject.Inject
@@ -10,12 +11,15 @@ import javax.inject.Inject
  */
 
 class MainActivityViewModel @Inject constructor(
-        val navigator: Navigator
+        private val navigator: Navigator,
+        private val repository: UserRepository
 ) : ActivityViewModel() {
     override fun onStart() {
+        decideLaunchActivity()
     }
 
     override fun onResume() {
+        decideLaunchActivity()
     }
 
     override fun onPause() {
@@ -28,5 +32,15 @@ class MainActivityViewModel @Inject constructor(
 
     fun onSignUpClicked(view: View) {
 
+    }
+
+    private fun decideLaunchActivity() {
+        repository.getAccessToken()
+                ?.subscribe({
+                    navigator.closeActivity()
+                    navigator.navigateToTopActivity()
+                }, {
+
+                })
     }
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
@@ -39,6 +39,7 @@ class SignInActivityViewModel @Inject constructor(
     fun onSignIn(view: View) {
         repository.signIn(mailAddress.get()?:"", password.get()?:"")
                 .subscribe({
+                    navigator.closeActivity()
                     navigator.navigateToTopActivity()
                 }, {
                     Snackbar.make(view, "missed signin", Snackbar.LENGTH_SHORT).show()


### PR DESCRIPTION
Close #150 

UserRepositoryに`getAccessToken`を追加し，sharedPrefにsigninと同時にaccesstokenを保存するようにした．

また，その情報をつかってはじめに起動するActivityを見るようにした．


長々と悩んでいたHeaderにどこでAuthorizationを挿すかの問題は，NetworkModuleでUserRepositoryを呼ぶにはAppModuleでprovideUserRepositoryしてる必要があり，その依存関係をごちゃごちゃしないといけなくて，なんか一般的じゃなさそうな気がした．

なので，解決策として，retrofitでクエリを投げるときに一緒にHeaderのパラメータを指定することにした．こうすれば`@Query`と同じ感じに扱えるので実現可能．
