### PR TITLE
viewmodelにいるviewを殺した

### DIFF
--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/BaseActivity.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/BaseActivity.kt
@@ -1,8 +1,6 @@
 package com.cyder.atsushi.youtubesync.view.activity
 
-import android.content.Context
 import android.support.v7.app.AppCompatActivity
-import android.view.inputmethod.InputMethodManager
 import com.cyder.atsushi.youtubesync.BaseApplication
 import com.cyder.atsushi.youtubesync.di.ActivityComponent
 import com.cyder.atsushi.youtubesync.di.ActivityModule
@@ -29,12 +27,6 @@ abstract class BaseActivity : AppCompatActivity() {
         this.viewModel = viewModel
     }
 
-    protected fun hideSoftwareKeyBoard() {
-        if (currentFocus != null) {
-            val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.hideSoftInputFromWindow(currentFocus.windowToken, 0)
-        }
-    }
 
     override fun onStart() {
         super.onStart()

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/BaseActivity.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/BaseActivity.kt
@@ -1,6 +1,8 @@
 package com.cyder.atsushi.youtubesync.view.activity
 
+import android.content.Context
 import android.support.v7.app.AppCompatActivity
+import android.view.inputmethod.InputMethodManager
 import com.cyder.atsushi.youtubesync.BaseApplication
 import com.cyder.atsushi.youtubesync.di.ActivityComponent
 import com.cyder.atsushi.youtubesync.di.ActivityModule
@@ -25,6 +27,13 @@ abstract class BaseActivity : AppCompatActivity() {
 
     protected fun bindViewModel(viewModel: ActivityViewModel) {
         this.viewModel = viewModel
+    }
+
+    protected fun hideSoftwareKeyBoard() {
+        if (currentFocus != null) {
+            val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(currentFocus.windowToken, 0)
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
@@ -53,12 +53,6 @@ class SignInActivity : BaseActivity() {
         viewModel.callback = callback
     }
 
-    private fun hideSoftwareKeyBoard() {
-        if (currentFocus != null) {
-            val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.hideSoftInputFromWindow(currentFocus.windowToken, 0)
-        }
-    }
 
 
     companion object {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.design.widget.Snackbar
-import android.view.inputmethod.InputMethodManager
 import com.cyder.atsushi.youtubesync.R
 import com.cyder.atsushi.youtubesync.databinding.ActivitySignInBinding
 import com.cyder.atsushi.youtubesync.viewmodel.SignInActivityViewModel
@@ -39,10 +38,10 @@ class SignInActivity : BaseActivity() {
 
     private fun setUpSnackbar() {
         callback = object : SignInActivityViewModel.SnackbarCallback {
-            override fun onSignInFailed() {
+            override fun onSignInFailed(resId: Int) {
                 hideSoftwareKeyBoard()
                 Snackbar.make(currentFocus,
-                        R.string.login_mistook,
+                        resId,
                         Snackbar.LENGTH_SHORT).apply {
                     setAction(R.string.ok) {
                         dismiss()

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.support.design.widget.Snackbar
 import com.cyder.atsushi.youtubesync.R
 import com.cyder.atsushi.youtubesync.databinding.ActivitySignInBinding
+import com.cyder.atsushi.youtubesync.view.helper.hideSoftwareKeyBoard
 import com.cyder.atsushi.youtubesync.viewmodel.SignInActivityViewModel
 import javax.inject.Inject
 
@@ -39,7 +40,7 @@ class SignInActivity : BaseActivity() {
     private fun setUpSnackbar() {
         callback = object : SignInActivityViewModel.SnackbarCallback {
             override fun onSignInFailed(resId: Int) {
-                hideSoftwareKeyBoard()
+                currentFocus.hideSoftwareKeyBoard()
                 Snackbar.make(currentFocus,
                         resId,
                         Snackbar.LENGTH_SHORT).apply {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/activity/SignInActivity.kt
@@ -4,10 +4,13 @@ import android.content.Context
 import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Bundle
+import android.support.design.widget.Snackbar
+import android.view.inputmethod.InputMethodManager
 import com.cyder.atsushi.youtubesync.R
 import com.cyder.atsushi.youtubesync.databinding.ActivitySignInBinding
 import com.cyder.atsushi.youtubesync.viewmodel.SignInActivityViewModel
 import javax.inject.Inject
+
 
 /**
  * Created by chigichan24 on 2018/01/17.
@@ -17,6 +20,7 @@ class SignInActivity : BaseActivity() {
 
     @Inject lateinit var viewModel: SignInActivityViewModel
     private lateinit var binding: ActivitySignInBinding
+    private lateinit var callback: SignInActivityViewModel.SnackbarCallback
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         getComponent().inject(this)
@@ -25,6 +29,35 @@ class SignInActivity : BaseActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_sign_in)
         binding.viewModel = viewModel
 
+        setUpSnackbar()
+    }
+
+    override fun onDestroy() {
+        viewModel.callback = null
+        super.onDestroy()
+    }
+
+    private fun setUpSnackbar() {
+        callback = object : SignInActivityViewModel.SnackbarCallback {
+            override fun onSignInFailed() {
+                hideSoftwareKeyBoard()
+                Snackbar.make(currentFocus,
+                        R.string.login_mistook,
+                        Snackbar.LENGTH_SHORT).apply {
+                    setAction(R.string.ok) {
+                        dismiss()
+                    }
+                }.show()
+            }
+        }
+        viewModel.callback = callback
+    }
+
+    private fun hideSoftwareKeyBoard() {
+        if (currentFocus != null) {
+            val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(currentFocus.windowToken, 0)
+        }
     }
 
 

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/helper/ViewHelper.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/view/helper/ViewHelper.kt
@@ -1,0 +1,14 @@
+package com.cyder.atsushi.youtubesync.view.helper
+
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+
+/**
+ * Created by chigichan24 on 2018/02/23.
+ */
+
+fun View.hideSoftwareKeyBoard() {
+    val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    imm.hideSoftInputFromWindow(this.windowToken, 0)
+}

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/MainActivityViewModel.kt
@@ -1,6 +1,5 @@
 package com.cyder.atsushi.youtubesync.viewmodel
 
-import android.view.View
 import com.cyder.atsushi.youtubesync.view.helper.Navigator
 import com.cyder.atsushi.youtubesync.viewmodel.base.ActivityViewModel
 import javax.inject.Inject
@@ -24,9 +23,9 @@ class MainActivityViewModel @Inject constructor(
     override fun onStop() {
     }
 
-    fun onSignInClicked(view: View) = navigator.navigateToSignInActivity()
+    fun onSignInClicked() = navigator.navigateToSignInActivity()
 
-    fun onSignUpClicked(view: View) {
+    fun onSignUpClicked() {
 
     }
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
@@ -34,7 +34,7 @@ class SignInActivityViewModel @Inject constructor(
 
     }
 
-    fun onBackButtonClicked(view: View) = navigator.closeActivity()
+    fun onBackButtonClicked() = navigator.closeActivity()
 
     fun onSignIn(view: View) {
         repository.signIn(mailAddress.get()?:"", password.get()?:"")

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
@@ -1,6 +1,7 @@
 package com.cyder.atsushi.youtubesync.viewmodel
 
 import android.databinding.ObservableField
+import com.cyder.atsushi.youtubesync.R
 import com.cyder.atsushi.youtubesync.repository.UserRepository
 import com.cyder.atsushi.youtubesync.view.helper.Navigator
 import com.cyder.atsushi.youtubesync.viewmodel.base.ActivityViewModel
@@ -19,7 +20,7 @@ class SignInActivityViewModel @Inject constructor(
     var callback: SnackbarCallback? = null
 
     interface SnackbarCallback {
-        fun onSignInFailed()
+        fun onSignInFailed(resId: Int)
     }
 
     override fun onStart() {
@@ -45,7 +46,7 @@ class SignInActivityViewModel @Inject constructor(
                 .subscribe({
                     navigator.navigateToTopActivity()
                 }, {
-                    callback?.onSignInFailed()
+                    callback?.onSignInFailed(R.string.login_mistook)
                 })
     }
 

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/SignInActivityViewModel.kt
@@ -1,8 +1,6 @@
 package com.cyder.atsushi.youtubesync.viewmodel
 
 import android.databinding.ObservableField
-import android.support.design.widget.Snackbar
-import android.view.View
 import com.cyder.atsushi.youtubesync.repository.UserRepository
 import com.cyder.atsushi.youtubesync.view.helper.Navigator
 import com.cyder.atsushi.youtubesync.viewmodel.base.ActivityViewModel
@@ -18,6 +16,12 @@ class SignInActivityViewModel @Inject constructor(
 ) : ActivityViewModel() {
     var mailAddress: ObservableField<String?> = ObservableField()
     var password: ObservableField<String?> = ObservableField()
+    var callback: SnackbarCallback? = null
+
+    interface SnackbarCallback {
+        fun onSignInFailed()
+    }
+
     override fun onStart() {
 
     }
@@ -36,12 +40,12 @@ class SignInActivityViewModel @Inject constructor(
 
     fun onBackButtonClicked() = navigator.closeActivity()
 
-    fun onSignIn(view: View) {
-        repository.signIn(mailAddress.get()?:"", password.get()?:"")
+    fun onSignIn() {
+        repository.signIn(mailAddress.get() ?: "", password.get() ?: "")
                 .subscribe({
                     navigator.navigateToTopActivity()
                 }, {
-                    Snackbar.make(view, "missed signin", Snackbar.LENGTH_SHORT).show()
+                    callback?.onSignInFailed()
                 })
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -50,7 +50,7 @@
                     android:layout_marginTop="10dp"
                     android:layout_weight="50"
                     android:background="@color/appBlue"
-                    android:onClick="@{viewModel::onSignInClicked}"
+                    android:onClick="@{(v) -> viewModel.onSignInClicked()}"
                     android:text="@string/login_button"
                     android:textColor="@color/appWhite"
                     android:textSize="18sp" />
@@ -63,7 +63,7 @@
                     android:layout_marginTop="10dp"
                     android:layout_weight="50"
                     android:background="@color/appGreen"
-                    android:onClick="@{viewModel::onSignUpClicked}"
+                    android:onClick="@{(v) -> viewModel.onSignUpClicked()}"
                     android:text="@string/new_register"
                     android:textColor="@color/appWhite"
                     android:textSize="18sp" />

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -70,7 +70,7 @@
                     android:text="@string/send_button"
                     android:textColor="@color/appWhite"
                     android:textSize="18sp"
-                    android:onClick="@{viewModel::onSignIn}"/>
+                    android:onClick="@{(v) -> viewModel.onSignIn()}"/>
             </LinearLayout>
         </ScrollView>
     </LinearLayout>

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -19,7 +19,7 @@
         <android.support.v7.widget.Toolbar
             app:title="@string/login_title"
             app:navigationIcon="@drawable/ic_arrow_back_black_24dp"
-            app:navigationOnClick="@{viewModel::onBackButtonClicked}"
+            app:navigationOnClick="@{(v) -> viewModel.onBackButtonClicked()}"
             android:id="@+id/sign_in_tool_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Close #153 

## やったこと
xmlの中でラムダ式をほげほげすることでviewmodel側にviewが混在することをなくした．

## なぜ？
なぜなら，MVVMではview-viewmodelはdatabindingでのみつながるべきだから．viewからviewmodelは参照できても逆はできてはいけない．

## どうやって？
`(v) -> ()`な感じのラムダ式をxmlで記述することで解決した．

## 問題点
Snackbarに関してはbindingで解決不能だったのでcallbackを挿した．